### PR TITLE
added config option to enable/disable logging

### DIFF
--- a/app/code/community/Inchoo/SoapLogger/Helper/Data.php
+++ b/app/code/community/Inchoo/SoapLogger/Helper/Data.php
@@ -55,13 +55,24 @@ class Inchoo_SoapLogger_Helper_Data extends Mage_Core_Helper_Abstract
             }
         }
     }
-
+    
     public function logMessage($message)
     {
-        Mage::log(
-            $message,
-            null,
-            $this->logFileName
-        );
+        if($this->_isSoapLoggingEnabled())
+        {
+            Mage::log(
+                $message,
+                null,
+                $this->logFileName
+            );
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    private function _isSoapLoggingEnabled()
+    {
+        return (bool)Mage::getStoreConfig('dev/log/soaplog_active');
     }
 }

--- a/app/code/community/Inchoo/SoapLogger/etc/config.xml
+++ b/app/code/community/Inchoo/SoapLogger/etc/config.xml
@@ -39,6 +39,13 @@
             <version>1.0.0</version>
         </Inchoo_SoapLogger>
     </modules>
+    <default>
+        <dev>
+            <log>
+                <soaplog_active>0</soaplog_active>
+            </log>
+        </dev>
+    </default>
     <global>
         <models>
             <api>

--- a/app/code/community/Inchoo/SoapLogger/etc/system.xml
+++ b/app/code/community/Inchoo/SoapLogger/etc/system.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config>
+    <sections>
+        <dev>
+            <groups>
+                <log>
+                    <fields>
+                        <soaplog_active translate="label">
+                            <label>Soap logging Enabled</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>1</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </soaplog_active>
+                    </fields>
+                </log>
+            </groups>
+        </dev>
+    </sections>
+</config>


### PR DESCRIPTION
I added an option to enable/disable the soap logging via the admin panel (system -> configuration -> advanced -> developer -> log -> Soap logging Enabled). Perhaps you consider it usefull.

Thnx for providing the soap logger module!